### PR TITLE
Redirect http to https for app.story.ai

### DIFF
--- a/app/main.tf
+++ b/app/main.tf
@@ -56,6 +56,32 @@ resource "google_compute_target_https_proxy" "default" {
 }
 
 # ------------------------------------------------------------------------------
+# HTTP to HTTPS redirect using 301s
+# ------------------------------------------------------------------------------
+
+resource "google_compute_url_map" "http-redirect" {
+  name = "http-redirect"
+
+  default_url_redirect {
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"  // 301 redirect
+    strip_query            = false
+    https_redirect         = true  // this is the magic
+  }
+}
+
+resource "google_compute_target_http_proxy" "http-redirect" {
+  name    = "http-redirect"
+  url_map = google_compute_url_map.http-redirect.self_link
+}
+
+resource "google_compute_global_forwarding_rule" "http-redirect" {
+  name       = "http-redirect"
+  target     = google_compute_target_http_proxy.http-redirect.self_link
+  ip_address = google_compute_global_address.default.address
+  port_range = "80"
+}
+
+# ------------------------------------------------------------------------------
 # CREATE A RECORD POINTING TO THE PUBLIC IP OF THE CLB
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Authors

@williammartin @thehabbos007 

### Topic

This PR is relating to https://www.pivotaltracker.com/story/show/178630270

### Implementation

The previous Load Balancer set up was using the Gruntworks TF module which provides nice stuff out of the box. Unfortunately, it doesn't support the ability to redirect http to https. We could have forked it, or contributed back (and maybe we should) but for the moment the easiest thing to do was to pull the module internals up to the top level, and then add a new proxy with a url map that redirects (see `google_compute_url_map.http-redirect`).

This has been deployed and you can see it working at:

http://app.story.ai 

which should redirect to:

https://app.story.ai